### PR TITLE
Updated dependencies to install latest aircrack-ng and airmon-ng IPK.

### DIFF
--- a/BessideNG/module.info
+++ b/BessideNG/module.info
@@ -1,10 +1,10 @@
 {
-    "author": "mattlawer",
+    "author": "mattlawer & adde88",
     "description": "Automated WiFi Hacking using besside-ng from the aircrack-ng suite",
     "devices": [
         "nano",
         "tetra"
     ],
     "title": "Besside-NG",
-    "version": "1.0"
+    "version": "1.1"
 }

--- a/BessideNG/scripts/autostart_besside.sh
+++ b/BessideNG/scripts/autostart_besside.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#2019 - mattlawer
+#2019 - mattlawer & adde88
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sd/lib:/sd/usr/lib
 export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin

--- a/BessideNG/scripts/besside.sh
+++ b/BessideNG/scripts/besside.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#2019 - mattlawer
+#2019 - mattlawer & adde88
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sd/lib:/sd/usr/lib
 export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin

--- a/BessideNG/scripts/dependencies.sh
+++ b/BessideNG/scripts/dependencies.sh
@@ -12,7 +12,7 @@ touch /tmp/BessideNG.progress
 mkdir -p /tmp/BessideNG
 wget https://github.com/adde88/aircrack-ng-openwrt/tree/master/bin/ar71xx/packages/base -P /tmp/BessideNG
 AIRMON=`grep -F "airmon-ng_" /tmp/BessideNG/base | awk {'print $5'} | awk -F'"' {'print $2'}`
-AIRCRACK=`grep -F "aircrack-ng_" /tmp/BessideNG/base | awk {'print $5'} | awk -F'"' {'print $2'}
+AIRCRACK=`grep -F "aircrack-ng_" /tmp/BessideNG/base | awk {'print $5'} | awk -F'"' {'print $2'}`
 
 if [ "$1" = "install" ]; then
   if [ "$2" = "internal" ]; then

--- a/BessideNG/scripts/dependencies.sh
+++ b/BessideNG/scripts/dependencies.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-#2019 - mattlawer
+#2019 - mattlawer & adde88
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/sd/lib:/sd/usr/lib
 export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin
@@ -9,16 +9,22 @@ export PATH=$PATH:/sd/usr/bin:/sd/usr/sbin
 }
 
 touch /tmp/BessideNG.progress
+mkdir -p /tmp/BessideNG
+wget https://github.com/adde88/aircrack-ng-openwrt/tree/master/bin/ar71xx/packages/base -P /tmp/BessideNG
+AIRMON=`grep -F "airmon-ng_" /tmp/BessideNG/base | awk {'print $5'} | awk -F'"' {'print $2'}`
+AIRCRACK=`grep -F "aircrack-ng_" /tmp/BessideNG/base | awk {'print $5'} | awk -F'"' {'print $2'}
 
 if [ "$1" = "install" ]; then
   if [ "$2" = "internal" ]; then
-  	# need to be more secure...
-    curl https://raw.githubusercontent.com/adde88/besside-ng_pineapple/master/besside-ng -o /usr/bin/besside-ng
-    chmod +x /usr/bin/besside-ng
+	wget https://github.com/adde88/aircrack-ng-openwrt/raw/master/bin/ar71xx/packages/base/"$AIRMON" -P /tmp/BessideNG
+	wget https://github.com/adde88/aircrack-ng-openwrt/raw/master/bin/ar71xx/packages/base/"$AIRCRACK" -P /tmp/BessideNG
+	opkg update
+	opkg install /tmp/BessideNG/*.ipk --force-overwrite
   elif [ "$2" = "sd" ]; then
-  	# need to be more secure...
-    curl https://raw.githubusercontent.com/adde88/besside-ng_pineapple/master/besside-ng -o /sd/usr/bin/besside-ng
-    chmod +x /sd/usr/bin/besside-ng
+	wget https://github.com/adde88/aircrack-ng-openwrt/raw/master/bin/ar71xx/packages/base/"$AIRMON" -P /tmp/BessideNG
+	wget https://github.com/adde88/aircrack-ng-openwrt/raw/master/bin/ar71xx/packages/base/"$AIRCRACK" -P /tmp/BessideNG
+	opkg update
+	opkg install /tmp/BessideNG/*.ipk --force-overwrite --dest sd
   fi
 
   touch /etc/config/BessideNG
@@ -30,9 +36,8 @@ if [ "$1" = "install" ]; then
   uci commit BessideNG.module.installed
 
 elif [ "$1" = "remove" ]; then
-  rm -rf /usr/bin/besside-ng
-  rm -rf /sd/usr/bin/besside-ng
   rm -rf /etc/config/BessideNG
 fi
 
 rm /tmp/BessideNG.progress
+rm -rf /tmp/BessideNG


### PR DESCRIPTION
Script will now install latest IPK from my repo: aircrack-ng-openwrt.
Which is more up-to-date compared to OpenWRT and Hak5. :)