### PR TITLE
Compatibility with 2.7.0 firmware

### DIFF
--- a/BessideNG/scripts/besside.sh
+++ b/BessideNG/scripts/besside.sh
@@ -50,5 +50,5 @@ elif [ "$1" = "stop" ]; then
 	if [ -f ${LOG} ]; then
 		echo -e " - stopping -" >> ${LOG}
 	fi
-  killall -9 besside-ng
+  killall -9 besside-ng sh
 fi

--- a/BessideNG/scripts/besside.sh
+++ b/BessideNG/scripts/besside.sh
@@ -50,5 +50,5 @@ elif [ "$1" = "stop" ]; then
 	if [ -f ${LOG} ]; then
 		echo -e " - stopping -" >> ${LOG}
 	fi
-  killall -9 besside-ng sh
+  ps aux | grep besside-ng | awk '{print $2}' | xargs kill -9
 fi

--- a/BessideNG/scripts/dependencies.sh
+++ b/BessideNG/scripts/dependencies.sh
@@ -12,18 +12,11 @@ touch /tmp/BessideNG.progress
 
 if [ "$1" = "install" ]; then
   if [ "$2" = "internal" ]; then
-    wget "https://github.com/adde88/besside-ng_pineapple/raw/openwrt-19.07/besside-ng" -O /usr/sbin/besside-ng
-    chmod +x /usr/sbin/besside-ng
-    opkg install libpciaccess libhwloc
-    cp /usr/lib/libhwloc.so.15.* /usr/lib/libhwloc.so.15
-    cp /usr/lib/libpciaccess.so.0.*  /usr/lib/libpciaccess.so.0
+    opkg remove aircrack-ng-hak5
+    opkg install aircrack-ng
   elif [ "$2" = "sd" ]; then
-    mkdir -p /sd/usr/sbin/
-    wget "https://github.com/adde88/besside-ng_pineapple/raw/openwrt-19.07/besside-ng" -O /sd/usr/sbin/besside-ng
-    chmod +x /sd/usr/sbin/besside-ng
-    opkg --dest sd install libpciaccess libhwloc
-    cp /sd/usr/lib/libhwloc.so.15.* /sd/usr/lib/libhwloc.so.15
-    cp /sd/usr/lib/libpciaccess.so.0.*  /sd/usr/lib/libpciaccess.so.0
+    opkg remove aircrack-ng-hak5
+    opkg --dest sd install aircrack-ng
   fi
 
   touch /etc/config/BessideNG
@@ -35,8 +28,7 @@ if [ "$1" = "install" ]; then
   uci commit BessideNG.module.installed
 
 elif [ "$1" = "remove" ]; then
-  rm -rf /usr/sbin/besside-ng
-  rm -rf /sd/usr/sbin/besside-ng
+  opkg remove aircrack-ng
   rm -rf /etc/config/BessideNG
 fi
 


### PR DESCRIPTION
- Use `besside-ng` from `aircrack-ng` package
- Fix for `besside-ng` process termination